### PR TITLE
Update LanguageRedirector.php to prevent Craft CMS from crashing when REQUEST_URI is not set

### DIFF
--- a/src/LanguageRedirector.php
+++ b/src/LanguageRedirector.php
@@ -23,7 +23,7 @@ class LanguageRedirector extends \craft\base\Plugin
         $default = $this->getSettings()->defaultLanguage;
         $urls = $this->getSettings()->urls;
 
-        if(!empty($urls)) {
+        if(!empty($urls) && isset($_SERVER['REQUEST_URI'])) {
             $browserLoc = new \koenster\PHPLanguageDetection\BrowserLocalization();
             $browserLoc->setAvailable(array_keys($urls))
                 ->setDefault($default)


### PR DESCRIPTION
We noticed that whenever we run `craft up` it would crash due to the following:

```PHP Warning 'yii\base\ErrorException' with message 'Undefined array key "REQUEST_URI"'

in /var/www/production/releases/20250403090635/vendor/liquidbcn/craftcms-language-redirect/src/LanguageRedirector.php:31

Stack trace:
#0 /var/www/production/releases/20250403090635/vendor/liquidbcn/craftcms-language-redirect/src/LanguageRedirector.php(31): yii\base\ErrorHandler->handleError()
#1 /var/www/production/releases/20250403090635/vendor/liquidbcn/craftcms-language-redirect/src/LanguageRedirector.php(16): liquidbcn\languageredirect\LanguageRedirector->redirect()
#2 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/base/BaseObject.php(109): liquidbcn\languageredirect\LanguageRedirector->init()
#3 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/base/Module.php(161): yii\base\BaseObject->__construct()
#4 /var/www/production/releases/20250403090635/vendor/craftcms/cms/src/base/Plugin.php(122): yii\base\Module->__construct()
#5 [internal function]: craft\base\Plugin->__construct()
#6 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/di/Container.php(419): ReflectionClass->newInstanceArgs()
#7 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/di/Container.php(170): yii\di\Container->build()
#8 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/BaseYii.php(365): yii\di\Container->get()
#9 /var/www/production/releases/20250403090635/vendor/craftcms/cms/src/Craft.php(59): yii\BaseYii::createObject()
#10 /var/www/production/releases/20250403090635/vendor/craftcms/cms/src/services/Plugins.php(943): Craft::createObject()
#11 /var/www/production/releases/20250403090635/vendor/craftcms/cms/src/services/Plugins.php(228): craft\services\Plugins->createPlugin()
#12 /var/www/production/releases/20250403090635/vendor/craftcms/cms/src/base/ApplicationTrait.php(1640): craft\services\Plugins->loadPlugins()
#13 /var/www/production/releases/20250403090635/vendor/craftcms/cms/src/console/Application.php(53): craft\console\Application->_postInit()
#14 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/base/BaseObject.php(109): craft\console\Application->init()
#15 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/base/Application.php(204): yii\base\BaseObject->__construct()
#16 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/console/Application.php(89): yii\base\Application->__construct()
#17 [internal function]: yii\console\Application->__construct()
#18 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/di/Container.php(419): ReflectionClass->newInstanceArgs()
#19 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/di/Container.php(170): yii\di\Container->build()
#20 /var/www/production/releases/20250403090635/vendor/yiisoft/yii2/BaseYii.php(365): yii\di\Container->get()
#21 /var/www/production/releases/20250403090635/vendor/craftcms/cms/src/Craft.php(59): yii\BaseYii::createObject()
#22 /var/www/production/releases/20250403090635/vendor/craftcms/cms/bootstrap/bootstrap.php(250): Craft::createObject()
#23 /var/www/production/releases/20250403090635/vendor/craftcms/cms/bootstrap/console.php(40): require('...')
#24 /var/www/production/releases/20250403090635/craft(12): require('...')
#25 {main}
```

This adjustment fixes that by adding an explicit check for that global.