### PR TITLE
Add multi-site domain-based configuration

### DIFF
--- a/src/LanguageRedirector.php
+++ b/src/LanguageRedirector.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace liquidbcn\languageredirect;
 
 use Craft;
@@ -37,16 +38,23 @@ class LanguageRedirector extends Plugin
         }
 
         $settings = $this->getSettings();
-        $urls = $settings->getUrlsAsAssociativeArray();
+
+        if (!$settings->isCurrentDomainEnabled()) {
+            return;
+        }
+
+        $urls = $settings->getUrlsForCurrentDomain();
 
         if (empty($urls)) {
             return;
         }
 
+        $defaultLanguage = $settings->getDefaultLanguageForCurrentDomain();
+
         $browser = $request->getHeaders()->get('accept-language');
         $browserLoc = new BrowserLocalization();
         $browserLoc->setAvailable(array_keys($urls))
-            ->setDefault($settings->defaultLanguage)
+            ->setDefault($defaultLanguage)
             ->setPreferences($browser);
 
         $language = $browserLoc->detect();

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -2,28 +2,188 @@
 
 namespace liquidbcn\languageredirect\models;
 
+use Craft;
 use craft\base\Model;
 use craft\helpers\ProjectConfig;
 
 class Settings extends Model
 {
+    public ?array $domains = null;
+
+    // Legacy properties for backward compatibility
     public string $defaultLanguage = 'en-GB';
     public ?array $urls = null;
 
     public function rules(): array
     {
         return [
-            ['defaultLanguage', 'required'],
+            ['domains', 'safe'],
             ['defaultLanguage', 'string'],
             ['urls', 'safe'],
         ];
     }
 
-    /**
-     * Converts editable table format to associative array
-     * Handles both direct config file format and Craft's project config format
-     */
-    public function getUrlsAsAssociativeArray(): array
+    public function getSitesGroupedByDomain(): array
+    {
+        $sites = Craft::$app->getSites()->getAllSites();
+        $domains = [];
+
+        foreach ($sites as $site) {
+            $baseUrl = Craft::parseEnv($site->baseUrl);
+            $parsed = parse_url($baseUrl);
+            $host = $parsed['host'] ?? 'unknown';
+            $path = $parsed['path'] ?? '/';
+
+            if ($path === '') {
+                $path = '/';
+            }
+
+            if (!isset($domains[$host])) {
+                $domains[$host] = [
+                    'host' => $host,
+                    'sites' => [],
+                ];
+            }
+
+            $domains[$host]['sites'][] = [
+                'id' => $site->id,
+                'name' => $site->name,
+                'language' => $site->language,
+                'path' => $path,
+            ];
+        }
+
+        // Add metadata
+        foreach ($domains as $host => &$domain) {
+            $languages = array_unique(array_column($domain['sites'], 'language'));
+            $domain['hasMultipleLanguages'] = count($languages) > 1;
+            $domain['languages'] = $languages;
+        }
+
+        return $domains;
+    }
+
+    public function getDomainConfig(string $host): array
+    {
+        $domains = $this->domains ?? [];
+        $domains = ProjectConfig::unpackAssociativeArrays($domains);
+
+        if (isset($domains[$host])) {
+            $config = $domains[$host];
+
+            if (isset($config['urls'])) {
+                $config['urls'] = ProjectConfig::unpackAssociativeArrays($config['urls']);
+            }
+
+            return $config;
+        }
+
+        return [
+            'enabled' => false,
+            'defaultLanguage' => '',
+            'urls' => [],
+        ];
+    }
+
+    public function isDomainEnabled(string $host): bool
+    {
+        $config = $this->getDomainConfig($host);
+
+        return !empty($config['enabled']);
+    }
+
+    public function getDomainUrls(string $host): array
+    {
+        $config = $this->getDomainConfig($host);
+        $urls = $config['urls'] ?? [];
+
+        if (empty($urls)) {
+            return [];
+        }
+
+        // Handle editable table format
+        if ($this->isIndexedArray($urls)) {
+            $result = [];
+            foreach ($urls as $row) {
+                if (is_array($row) && !empty($row['locale']) && !empty($row['url'])) {
+                    $result[$row['locale']] = $row['url'];
+                }
+            }
+
+            return $result;
+        }
+
+        return $urls;
+    }
+
+    public function getDomainDefaultLanguage(string $host): string
+    {
+        $config = $this->getDomainConfig($host);
+        $defaultLanguage = $config['defaultLanguage'] ?? '';
+
+        if ($defaultLanguage !== '') {
+            return $defaultLanguage;
+        }
+
+        // Fallback to first available language from URL mappings
+        $urls = $this->getDomainUrls($host);
+
+        if (!empty($urls)) {
+            return array_key_first($urls);
+        }
+
+        return '';
+    }
+
+    public function getUrlsForCurrentDomain(): array
+    {
+        $currentHost = $this->getCurrentHost();
+
+        // Try new domain-based config first
+        if ($this->isDomainEnabled($currentHost)) {
+            return $this->getDomainUrls($currentHost);
+        }
+
+        // Fall back to legacy config
+        return $this->getLegacyUrlsAsAssociativeArray();
+    }
+
+    public function getDefaultLanguageForCurrentDomain(): string
+    {
+        $currentHost = $this->getCurrentHost();
+
+        // Try new domain-based config first
+        if ($this->isDomainEnabled($currentHost)) {
+            return $this->getDomainDefaultLanguage($currentHost);
+        }
+
+        // Fall back to legacy config
+        return $this->defaultLanguage;
+    }
+
+    public function isCurrentDomainEnabled(): bool
+    {
+        $currentHost = $this->getCurrentHost();
+
+        // If using new domain config
+        if (!empty($this->domains)) {
+            return $this->isDomainEnabled($currentHost);
+        }
+
+        // Legacy: enabled if urls are configured
+        return !empty($this->urls);
+    }
+
+    private function getCurrentHost(): string
+    {
+        $currentSite = Craft::$app->getSites()->getCurrentSite();
+        $baseUrl = Craft::parseEnv($currentSite->baseUrl);
+        $parsed = parse_url($baseUrl);
+
+        return $parsed['host'] ?? '';
+    }
+
+    private function getLegacyUrlsAsAssociativeArray(): array
     {
         if (empty($this->urls)) {
             return [];
@@ -31,7 +191,7 @@ class Settings extends Model
 
         $urls = ProjectConfig::unpackAssociativeArrays($this->urls);
 
-        if ($this->isAssociativeArray($urls)) {
+        if (!$this->isIndexedArray($urls)) {
             return $urls;
         }
 
@@ -45,35 +205,12 @@ class Settings extends Model
         return $result;
     }
 
-    /**
-     * Converts associative array to editable table format for the CP
-     */
-    public function getUrlsAsTableRows(): array
-    {
-        if (empty($this->urls)) {
-            return [];
-        }
-
-        $urls = ProjectConfig::unpackAssociativeArrays($this->urls);
-
-        if ($this->isAssociativeArray($urls)) {
-            $result = [];
-            foreach ($urls as $locale => $url) {
-                $result[] = ['locale' => $locale, 'url' => $url];
-            }
-
-            return $result;
-        }
-
-        return $urls;
-    }
-
-    private function isAssociativeArray(array $arr): bool
+    private function isIndexedArray(array $arr): bool
     {
         if (empty($arr)) {
             return false;
         }
 
-        return array_keys($arr) !== range(0, count($arr) - 1);
+        return array_keys($arr) === range(0, count($arr) - 1);
     }
 }

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -1,34 +1,239 @@
 {% import '_includes/forms.twig' as forms %}
 
-{{ forms.textField({
-    label: 'Default Language'|t('language-redirect'),
-    instructions: 'The fallback locale code if the browser language is not in the URL list (e.g., en-GB, es-ES)'|t('language-redirect'),
-    id: 'defaultLanguage',
-    name: 'defaultLanguage',
-    value: settings.defaultLanguage,
-    required: true,
-}) }}
+{% set domainsData = settings.getSitesGroupedByDomain() %}
 
-{{ forms.editableTableField({
-    label: 'Language URLs'|t('language-redirect'),
-    instructions: 'Map browser locale codes to your site URLs. Users visiting the root path will be redirected based on their browser language.'|t('language-redirect'),
-    id: 'urls',
-    name: 'urls',
-    cols: {
-        locale: {
-            heading: 'Locale'|t('language-redirect'),
-            type: 'singleline',
-            placeholder: 'en-GB',
-        },
-        url: {
-            heading: 'URL'|t('language-redirect'),
-            type: 'singleline',
-            placeholder: '/en/',
-        },
-    },
-    rows: settings.getUrlsAsTableRows(),
-    allowAdd: true,
-    allowDelete: true,
-    allowReorder: true,
-    minRows: 1,
-}) }}
+<style>
+.lr-domain-block {
+    border: 1px solid #cdd8e4;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 24px;
+    background: #fff;
+}
+.lr-domain-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #e3e5e8;
+}
+.lr-domain-header .field {
+    margin: 0 !important;
+}
+.lr-domain-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1a1a1a;
+}
+.lr-domain-sites {
+    margin-bottom: 16px;
+}
+.lr-domain-site-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 8px;
+    font-size: 13px;
+}
+.lr-domain-site-row code {
+    font-weight: 600;
+    color: #3b5998;
+    background: #f0f4f8;
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+.lr-domain-site-row .lr-site-names {
+    color: #666;
+}
+.lr-domain-warning {
+    color: #92400e;
+    background: #fef3c7;
+    padding: 12px;
+    border-radius: 4px;
+    font-size: 13px;
+    margin-bottom: 8px;
+}
+.lr-domain-info {
+    color: #1e40af;
+    background: #dbeafe;
+    padding: 12px;
+    border-radius: 4px;
+    font-size: 13px;
+}
+.lr-domain-content {
+    margin-top: 16px;
+}
+.lr-auto-fill-btn {
+    margin-top: -8px;
+    margin-bottom: 16px;
+}
+.lr-switch-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+</style>
+
+{% for host, domain in domainsData %}
+    {% set domainConfig = settings.getDomainConfig(host) %}
+    {% set isEnabled = domainConfig.enabled ?? false %}
+    {% set domainId = 'domain-' ~ loop.index %}
+    {% set isUnknown = host == 'unknown' %}
+    {% set canEnable = domain.hasMultipleLanguages and not isUnknown %}
+
+    {# Group sites by language #}
+    {% set sitesByLanguage = {} %}
+    {% for site in domain.sites %}
+        {% set lang = site.language %}
+        {% if sitesByLanguage[lang] is not defined %}
+            {% set sitesByLanguage = sitesByLanguage|merge({ (lang): { path: site.path, names: [] } }) %}
+        {% endif %}
+        {% set sitesByLanguage = sitesByLanguage|merge({
+            (lang): sitesByLanguage[lang]|merge({ names: sitesByLanguage[lang].names|merge([site.name]) })
+        }) %}
+    {% endfor %}
+
+    <div class="lr-domain-block" data-domain="{{ host }}">
+        <div class="lr-domain-header">
+            <span class="lr-domain-name">{{ host }}</span>
+            <div class="{{ not canEnable ? 'lr-switch-disabled' : '' }}">
+                {{ forms.lightswitchField({
+                    id: domainId ~ '-enabled',
+                    name: 'domains[' ~ host ~ '][enabled]',
+                    on: isEnabled and canEnable,
+                    small: true,
+                    toggle: '#' ~ domainId ~ '-content',
+                    disabled: not canEnable,
+                }) }}
+            </div>
+        </div>
+
+        {% if isUnknown %}
+            <div class="lr-domain-warning">
+                Could not detect domain from site URLs. Please configure Base URL in Settings → Sites.
+            </div>
+        {% endif %}
+
+        <div class="lr-domain-sites">
+            {% for lang, data in sitesByLanguage %}
+                <div class="lr-domain-site-row">
+                    <code>{{ lang }}</code>
+                    <span>→</span>
+                    <code>{{ data.path }}</code>
+                    <span class="lr-site-names">({{ data.names|join(', ') }})</span>
+                </div>
+            {% endfor %}
+        </div>
+
+        {% if not domain.hasMultipleLanguages %}
+            <div class="lr-domain-info">
+                Only 1 language detected. Language redirect is not available for this domain.
+            </div>
+        {% elseif canEnable %}
+            <div class="lr-domain-content" id="{{ domainId }}-content" {% if not isEnabled %}class="hidden"{% endif %}>
+                {% set domainUrls = domainConfig.urls ?? [] %}
+
+                {{ forms.selectField({
+                    label: 'Default Language'|t('language-redirect'),
+                    instructions: 'Fallback language if browser language is not in the list'|t('language-redirect'),
+                    id: domainId ~ '-defaultLanguage',
+                    name: 'domains[' ~ host ~ '][defaultLanguage]',
+                    options: domain.languages|map(lang => { label: lang, value: lang }),
+                    value: domainConfig.defaultLanguage ?? (domain.languages[0] ?? ''),
+                }) }}
+
+                {{ forms.editableTableField({
+                    label: 'URL Mappings'|t('language-redirect'),
+                    instructions: 'Map browser locale codes to URL paths. Use short codes (en, es) to match all regional variants (en-US, en-GB). Add specific codes (es-MX) for regional overrides.'|t('language-redirect'),
+                    id: domainId ~ '-urls',
+                    name: 'domains[' ~ host ~ '][urls]',
+                    cols: {
+                        locale: {
+                            heading: 'Locale'|t('language-redirect'),
+                            type: 'singleline',
+                            placeholder: 'en',
+                        },
+                        url: {
+                            heading: 'URL'|t('language-redirect'),
+                            type: 'singleline',
+                            placeholder: '/',
+                        },
+                    },
+                    rows: domainUrls,
+                    allowAdd: true,
+                    allowDelete: true,
+                    allowReorder: true,
+                    minRows: 1,
+                }) }}
+
+                <button type="button" class="btn lr-auto-fill-btn" data-domain="{{ host }}" data-domain-id="{{ domainId }}">
+                    {{ 'Auto-fill from detected sites'|t('language-redirect') }}
+                </button>
+            </div>
+        {% endif %}
+    </div>
+{% endfor %}
+
+<script>
+(function() {
+    var domainsData = {{ domainsData|json_encode|raw }};
+
+    // Auto-fill button - uses unique language/path combinations
+    document.querySelectorAll('.lr-auto-fill-btn').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var host = this.dataset.domain;
+            var domainId = this.dataset.domainId;
+            var domain = domainsData[host];
+
+            if (!domain || !domain.sites) {
+                Craft.cp.displayError('No sites found for this domain');
+                return;
+            }
+
+            // Get unique language/path combinations
+            var uniqueSites = [];
+            var seen = {};
+            domain.sites.forEach(function(site) {
+                var key = site.language + '|' + site.path;
+                if (!seen[key]) {
+                    seen[key] = true;
+                    uniqueSites.push(site);
+                }
+            });
+
+            var $table = $('#settings-' + domainId + '-urls');
+            var editableTable = $table.data('editable-table');
+
+            if (!editableTable) {
+                Craft.cp.displayError('Could not find table');
+                return;
+            }
+
+            // Remove extra rows
+            var $allRows = editableTable.$tbody.children('tr');
+            for (var i = $allRows.length - 1; i > 0; i--) {
+                $allRows.eq(i).find('button.delete').trigger('click');
+            }
+
+            // Add unique sites
+            uniqueSites.forEach(function(site, siteIndex) {
+                if (siteIndex > 0) {
+                    editableTable.addRow(false);
+                }
+
+                var $row = editableTable.$tbody.children('tr').eq(siteIndex);
+                var $localeTextarea = $row.find('textarea[name*="[locale]"]');
+                var $urlTextarea = $row.find('textarea[name*="[url]"]');
+
+                $localeTextarea.val(site.language);
+                $urlTextarea.val(site.path);
+
+                $localeTextarea.prev('.editable-table-preview').text(site.language);
+                $urlTextarea.prev('.editable-table-preview').text(site.path);
+            });
+
+            Craft.cp.displayNotice('URLs filled from detected sites');
+        });
+    });
+})();
+</script>


### PR DESCRIPTION
## Summary

- Refactored settings UI to organize configuration by domain
- Auto-detects Craft sites and groups them by domain
- Per-domain enable/disable with lightswitch toggle
- Automatically disables redirect for domains with only 1 language
- Shows warning for sites with unconfigured Base URL
- Auto-fill button populates URL mappings from detected sites
- Maintains backward compatibility with legacy config format

## Changes

**Settings.php:**
- New `domains` property for per-domain configuration
- `getSitesGroupedByDomain()` - groups all Craft sites by host
- `getDomainConfig()`, `isDomainEnabled()`, `getDomainUrls()` - domain getters
- `getUrlsForCurrentDomain()`, `isCurrentDomainEnabled()` - used by redirect logic
- Legacy `defaultLanguage` and `urls` still supported for backward compatibility

**settings.twig:**
- Domain blocks with enable/disable lightswitch
- Sites grouped by language (e.g., `en → / (Site1, Site2)`)
- Warning for "unknown" domains (missing Base URL config)
- Info message for single-language domains
- Auto-fill button with duplicate filtering

**LanguageRedirector.php:**
- Uses new domain-based methods
- Falls back to legacy config if no domain config exists

## Test plan

- [ ] Test redirect works with `Accept-Language: es-ES` → redirects to `/es/`
- [ ] Test redirect works with `Accept-Language: en-GB` → redirects to `/`
- [ ] Test fallback language works for unsupported locales
- [ ] Test lightswitch toggle shows/hides configuration
- [ ] Test auto-fill button populates URL mappings
- [ ] Test backward compatibility with existing config files